### PR TITLE
Add README and prompt utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# SONA Release
+
+This repository contains the official implementation for the paper ["SONA"](https://arxiv.org/pdf/2408.14841).
+It provides two major components:
+
+- `classifier/` – training code for the image classifier used in the paper.
+- `generator/` – utilities and pipelines for generating Synthetic OOD Noise Augmentation (SONA) samples using Stable Diffusion.
+
+## Installation
+
+The code requires Python 3.8+ and PyTorch.  Install dependencies with
+
+```bash
+pip install -r requirements.txt
+```
+
+The generator additionally depends on `diffusers` and `transformers`.
+
+## Training a Classifier
+
+The classifier can be trained on ImageNet‑200 as follows:
+
+```bash
+python classifier/train.py --dataset in200 \
+    --id_train_dir <path-to-id-train> \
+    --id_train_vae_dir <path-to-id-vae-train> \
+    --id_test_dir <path-to-id-val> \
+    --ood_dir <path-to-generated-sona> \
+    --save <output-dir>
+```
+
+Adjust the dataset paths to your environment.  Checkpoints are saved to the directory specified by `--save`.
+
+## Generating SONA Samples
+
+SONA images are generated using the Stable Diffusion pipeline defined in
+`generator/pipelines/pipeline_sona.py`.  A convenience script is provided:
+
+```bash
+python generator/generate_sona.py --dataset imagenet \
+    --datadir <image-root> \
+    --pretrained stabilityai/stable-diffusion-2-base \
+    --save_dir samples
+```
+
+The script reads class names from `generator/utils/classnames.txt` and saves
+edited images under the directory given by `--save_dir`.
+
+### Prompt Utilities
+
+Prompt generation utilities live in `generator/utils/prompt_utils.py`.  These
+provide helper functions for deterministic prompt creation and OOD word
+selection.
+
+## Repository Structure
+
+```
+classifier/              # ResNet‑18 classifier and training script
+    network.py
+    train.py
+
+generator/               # Stable Diffusion based generator
+    datasets.py          # Dataset loading helpers
+    generate_sona.py     # Entry point for image generation
+    pipelines/           # Diffusion pipelines
+    schedulers/          # Custom scheduler implementations
+    utils/               # Utility scripts and resources
+```
+
+Both `classifier` and `generator` are Python packages and can be imported.
+
+## License
+
+This project is released under the Apache 2.0 License.

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -1,0 +1,1 @@
+"Classifier package"

--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -1,0 +1,1 @@
+"Generator package"

--- a/generator/utils/prompt_utils.py
+++ b/generator/utils/prompt_utils.py
@@ -1,0 +1,44 @@
+import os
+import random
+import hashlib
+
+import utils.util as util
+
+IMAGENET_PROMPT_TEMPLATES = [
+    "a photo of a {}",
+]
+
+
+def get_seed_from_filename(filename: str) -> int:
+    """Generate a deterministic seed from a filename."""
+    hash_object = hashlib.sha256(filename.encode())
+    hash_digest = hash_object.hexdigest()
+    seed = int(hash_digest, 16) % (10**10)
+    return seed
+
+
+def get_ood_list(dataset):
+    """Return a list of OOD words and id-to-class mapping for prompts."""
+    idx2folder = {v: k for k, v in dataset.class_to_idx.items()}
+    folder2class = util.read_classnames('./utils/classnames.txt')
+    idx2class = {idx: folder2class[folder] for idx, folder in idx2folder.items()}
+    ood_word_list = util.find_ood_words(folder2class, idx2folder)
+    return ood_word_list, idx2class
+
+
+def select_random_word2prompt(y_batch, id_word_dict, file_names, ood_word_list):
+    """Return prompts for ID and OOD words using deterministic seeds."""
+    extracted_names = [os.path.basename(name) for name in file_names]
+
+    id_editing_prompts, ood_editing_prompts = [], []
+    for idx, y in enumerate(y_batch):
+        seed = get_seed_from_filename(extracted_names[idx])
+        random.seed(seed)
+
+        id_prompt = random.choice(IMAGENET_PROMPT_TEMPLATES).format(id_word_dict[y.item()])
+        id_editing_prompts.append(id_prompt)
+        ood_prompt = random.choice(IMAGENET_PROMPT_TEMPLATES).format(random.choice(ood_word_list))
+        ood_editing_prompts.append(ood_prompt)
+
+    editing_prompts = id_editing_prompts + id_editing_prompts + ood_editing_prompts
+    return editing_prompts


### PR DESCRIPTION
## Summary
- add detailed README with usage instructions
- modularize prompt utilities
- expose classifier and generator as packages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e919705988333bcec17cf4d0e3c35